### PR TITLE
Replace the short array syntax [] with array() for PHP 5.3.x.

### DIFF
--- a/sdk/Dropbox/Files.php
+++ b/sdk/Dropbox/Files.php
@@ -346,13 +346,13 @@
 
         public function getThumbnailSize($size)
         {
-            $thumbnailSizes = [
+            $thumbnailSizes = array(
                 'thumb' => 'w32h32',
                 'small' => 'w64h64',
                 'medium' => 'w128h128',
                 'large' => 'w640h480',
                 'huge' => 'w1024h768'
-            ];
+            );
             return isset($thumbnailSizes[$size]) ? $thumbnailSizes[$size] : $thumbnailSizes['small'];
         }
 


### PR DESCRIPTION
Files.php causes a fatal error with PHP 5.3.29, because of using the short array syntax.
